### PR TITLE
Add support for DITA Open Toolkit.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2019 Fonto http://fontoxml.com
+Copyright (c) 2019 - 2022 Fonto https://fontoxml.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # dita-example-schema-bundle
 
-> This is an example schema bundle for DITA 1.3 element support in FontoXML. The code in this repository is for
-  educational purposes. FontoXML does not provide any warranty with regards to feature-completeness or stability of this
-  package. Please see the license file for more information.
+> This is an example schema bundle for DITA 1.3 element support in FontoXML. The code in this repository is for educational purposes. FontoXML does not provide any warranty with regards to feature-completeness or stability of this package. Please see the license file for more information.
 
 This software contains the DITA 1.3 + MathML 3 XSD schema files with the following changes:
 
@@ -14,10 +12,20 @@ slightly stricter schema version.
 
 Please review [fonto.json](./fonto.json) for the schema locations correlating with each shell.
 
-## To use
+## Fonto Editor schema compilation
 
-- Create a ZIP archive for the contents of this repository.
+This repository can be used to create schema packages required for the Fonto Editor to function.
 
-- Follow the instructions to [integrate a schema](
-  http://documentation.fontoxml.com/editor/latest/integrate-a-schema-3099089.html) in your FontoXML editor as per
-  normal.
+Follow the instructions on [How to compile an updated schema into an existing editor](https://documentation.fontoxml.com/latest/re-compile-the-schema-1fe416604f65).
+
+## DITA Open Toolkit plugin
+
+This repository doubles as a [DITA Open Toolkit](https://www.dita-ot.org/download) plugin.
+
+1. Install the plugin using `dita install` ([documentation](https://www.dita-ot.org/dev/topics/plugins-installing.html)).
+
+1. Validate that the plugin was installed succesfully using `dita plugins` ([documentation](https://www.dita-ot.org/dev/parameters/dita-command-arguments.html#plugins)).
+
+## License
+
+This project is licensed under [MIT](http://www.opensource.org/licenses/mit-license.php "Read more about the MIT license form"). Refer to [LICENCE.md](./LICENSE.md) for more information.

--- a/catalog.xml
+++ b/catalog.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-   <nextCatalog catalog="schema/catalog.xml"/>
+	<nextCatalog catalog="schema/catalog.xml"/>
 </catalog>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin id="com.fontoxml.dita.v1_3.schema.bundle">
+	<feature extension="dita.specialization.catalog.relative" file="catalog.xml"/>
+</plugin>


### PR DESCRIPTION
This change adds support for installing the repository as a [DITA Open Toolkit](https://www.dita-ot.org/download) plugin.

When merged, it allows installing the repository as a zip archive or through a remote zip archive using the Github archive URL.